### PR TITLE
Improve image handling and documentation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -233,6 +233,7 @@ body.site--dark {
 /* Responsive images */
 .post__figure {
     margin: 0 0 1rem;
+    aspect-ratio: 2 / 1;
 }
 
 .post__image {

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -9,3 +9,7 @@ Initial Lighthouse metrics measured locally.
 | Cumulative Layout Shift (CLS) | 0.01 |
 
 JSON reports are stored under [docs/perf-reports](perf-reports/).
+
+## Image Dimensions
+
+Images for articles and news items use a 2:1 aspect ratio. Placeholder files are provided at 800x400 px and 400x200 px sizes, and these values are set as `width` and `height` attributes to avoid layout shifts.

--- a/pages/article.html
+++ b/pages/article.html
@@ -49,7 +49,7 @@
             <h2 class="post__title">AI Breakthrough in Generative Models</h2>
             <p class="post__meta"><time datetime="2024-04-01">April 1, 2024</time> by Admin</p>
             <figure class="post__figure">
-                <img class="post__image" src="../assets/images/article-800.txt" srcset="../assets/images/article-400.txt 400w, ../assets/images/article-800.txt 800w, ../assets/images/article-1200.txt 1200w" sizes="(max-width: 600px) 100vw, 800px" alt="Abstract generative AI concept">
+                <img class="post__image" src="../assets/images/article-800.txt" srcset="../assets/images/article-400.txt 400w, ../assets/images/article-800.txt 800w, ../assets/images/article-1200.txt 1200w" sizes="(max-width: 600px) 100vw, 800px" alt="Abstract generative AI concept" width="800" height="400" loading="lazy">
             </figure>
             <p class="post__content">This article discusses a significant leap forward in generative AI technology, enabling new forms of content creation and automation...</p>
             <div class="share" aria-label="Share">

--- a/pages/news.html
+++ b/pages/news.html
@@ -42,7 +42,7 @@
             <div class="news-list__grid" aria-live="polite">
                 <article class="post">
                     <figure class="post__figure">
-                        <img class="post__image" src="../assets/images/article-400.txt" alt="Abstract generative AI concept">
+                        <img class="post__image" src="../assets/images/article-400.txt" alt="Abstract generative AI concept" width="400" height="200" loading="lazy">
                     </figure>
                     <h3 class="post__title"><a href="article.html">OpenAI Releases New Text Generator</a></h3>
                     <p class="post__meta">April 1, 2024</p>
@@ -50,7 +50,7 @@
                 </article>
                 <article class="post">
                     <figure class="post__figure">
-                        <img class="post__image" src="../assets/images/article-400.txt" alt="Generative design illustration">
+                        <img class="post__image" src="../assets/images/article-400.txt" alt="Generative design illustration" width="400" height="200" loading="lazy">
                     </figure>
                     <h3 class="post__title"><a href="article.html">Startups Embrace Generative Design</a></h3>
                     <p class="post__meta">March 20, 2024</p>

--- a/pages/paper.html
+++ b/pages/paper.html
@@ -52,7 +52,7 @@
             <h2 class="post__title">Diffusion Models for Image Synthesis</h2>
             <p class="post__meta">Category: Vision</p>
             <figure class="post__figure">
-                <img class="post__image" src="../assets/images/paper-800.txt" srcset="../assets/images/paper-400.txt 400w, ../assets/images/paper-800.txt 800w, ../assets/images/paper-1200.txt 1200w" sizes="(max-width: 600px) 100vw, 800px" alt="Diffusion model illustration">
+                <img class="post__image" src="../assets/images/paper-800.txt" srcset="../assets/images/paper-400.txt 400w, ../assets/images/paper-800.txt 800w, ../assets/images/paper-1200.txt 1200w" sizes="(max-width: 600px) 100vw, 800px" alt="Diffusion model illustration" width="800" height="400" loading="lazy">
             </figure>
             <p class="post__abstract"><strong>Abstract:</strong> This research introduces a novel diffusion-based approach for generating realistic images. Experimental results show state-of-the-art performance on multiple benchmarks.</p>
             <p class="post__authors"><strong>Authors:</strong> Alice Researcher, Bob Scientist</p>


### PR DESCRIPTION
## Summary
- lazily load images and define explicit dimensions
- enforce 2:1 aspect ratio for post figures
- document image dimensions in performance baseline

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863216006648322a11ea593c317a943