### PR TITLE
Add ContentManager module with dynamic filtering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -431,3 +431,20 @@ textarea:focus-visible {
     .social,
     .loader { display: none !important; }
 }
+
+/* Content Manager */
+.content--loading::after {
+    content: 'Loading...';
+    display: block;
+    text-align: center;
+    padding: 1rem;
+    color: var(--text-color);
+}
+
+.post__bookmark {
+    background: none;
+    border: none;
+    cursor: pointer;
+    margin-left: 0.5rem;
+    font-size: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
     <script defer src="assets/js/filter.cjs"></script>
     <script defer src="js/autocomplete.cjs"></script>
     <script defer src="assets/js/main.js"></script>
+    <script type="module" src="js/content-manager.js"></script>
 </head>
 <body class="site site--light">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/js/content-manager.js
+++ b/js/content-manager.js
@@ -1,0 +1,128 @@
+(function(global){
+  class ContentManager {
+    constructor(options = {}) {
+      this.articleUrl = options.articleUrl || 'content/sample_articles.json';
+      this.storage = options.storage || window.localStorage;
+      this.timeout = options.timeout || 8000;
+      this.articles = [];
+      this.searchInput = null;
+      this.categorySelect = null;
+      this.list = null;
+    }
+
+    async fetchJSON(url) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), this.timeout);
+      try {
+        const res = await fetch(url, { signal: controller.signal });
+        clearTimeout(timer);
+        if (!res.ok) throw new Error('BadResponse');
+        return await res.json();
+      } catch (e) {
+        clearTimeout(timer);
+        throw new Error('ContentFetchError');
+      }
+    }
+
+    async load() {
+      try {
+        this.setLoading(true);
+        this.articles = await this.fetchJSON(this.articleUrl);
+        this.setLoading(false);
+        this.render(this.articles);
+      } catch (e) {
+        this.setLoading(false);
+        this.setError('Failed to load content');
+      }
+    }
+
+    attach(opts = {}) {
+      this.searchInput = document.querySelector(opts.searchInput);
+      this.categorySelect = document.querySelector(opts.categorySelect);
+      this.list = document.querySelector(opts.list);
+      this.searchInput && this.searchInput.addEventListener('input', () => this.update());
+      this.categorySelect && this.categorySelect.addEventListener('change', () => this.update());
+      this.load();
+    }
+
+    update() {
+      const term = this.searchInput ? this.searchInput.value : '';
+      const cat = this.categorySelect ? this.categorySelect.value : 'all';
+      const items = this.filter(term, cat);
+      this.render(items);
+    }
+
+    filter(term = '', category = 'all') {
+      const q = term.trim().toLowerCase();
+      return this.articles.filter(a => {
+        const title = (a.title || '').toLowerCase();
+        const cat = (a.category || '').toLowerCase();
+        const tMatch = !q || title.includes(q);
+        const cMatch = category === 'all' || cat === category.toLowerCase();
+        return tMatch && cMatch;
+      });
+    }
+
+    render(items) {
+      if (!this.list) return;
+      this.list.innerHTML = '';
+      items.forEach(a => {
+        const el = document.createElement('article');
+        el.className = 'post';
+        el.innerHTML = `<h3 class="post__title">${a.title}</h3>`+
+                       `<p class="post__meta">Category: ${a.category || ''}</p>`+
+                       `<p class="post__excerpt">${a.excerpt || a.summary || ''}</p>`;
+        const bm = document.createElement('button');
+        bm.className = 'post__bookmark';
+        bm.type = 'button';
+        bm.textContent = this.isBookmarked(a.id) ? '★' : '☆';
+        bm.addEventListener('click', () => {
+          this.toggleBookmark(a.id);
+          bm.textContent = this.isBookmarked(a.id) ? '★' : '☆';
+        });
+        el.appendChild(bm);
+        this.list.appendChild(el);
+      });
+    }
+
+    toggleBookmark(id) {
+      const set = new Set(JSON.parse(this.storage.getItem('bookmarks') || '[]'));
+      set.has(id) ? set.delete(id) : set.add(id);
+      this.storage.setItem('bookmarks', JSON.stringify([...set]));
+    }
+
+    isBookmarked(id) {
+      return JSON.parse(this.storage.getItem('bookmarks') || '[]').includes(id);
+    }
+
+    saveProgress(id, val) {
+      const prog = JSON.parse(this.storage.getItem('progress') || '{}');
+      prog[id] = val;
+      this.storage.setItem('progress', JSON.stringify(prog));
+    }
+
+    trackReading(id) {
+      window.addEventListener('scroll', () => {
+        const d = document.documentElement;
+        const pct = d.scrollTop / (d.scrollHeight - d.clientHeight);
+        this.saveProgress(id, pct);
+      });
+    }
+
+    setLoading(on) {
+      this.list && this.list.classList.toggle('content--loading', on);
+    }
+
+    setError(msg) {
+      if (!this.list) return;
+      this.list.textContent = msg;
+      this.list.classList.add('content--error');
+    }
+  }
+
+  if (typeof module === 'object' && module.exports) {
+    module.exports = ContentManager;
+  } else {
+    global.ContentManager = ContentManager;
+  }
+})(this);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "collectCoverageFrom": [
       "assets/js/filter.cjs",
       "assets/js/main.js",
-      "js/autocomplete.cjs"
+      "js/autocomplete.cjs",
+      "js/content-manager.js"
     ],
     "testMatch": [
       "**/?(*.)+(test).cjs"

--- a/pages/article.html
+++ b/pages/article.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="../css/style.css">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
+    <script type="module" src="../js/content-manager.js"></script>
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/pages/news.html
+++ b/pages/news.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="../css/style.css">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
+    <script type="module" src="../js/content-manager.js"></script>
 </head>
 <body class="site site--light">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/pages/paper.html
+++ b/pages/paper.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="../css/style.css">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
+    <script type="module" src="../js/content-manager.js"></script>
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/pages/research.html
+++ b/pages/research.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="../css/style.css">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
+    <script type="module" src="../js/content-manager.js"></script>
 </head>
 <body class="site site--light">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/test/content-manager.test.cjs
+++ b/test/content-manager.test.cjs
@@ -1,0 +1,66 @@
+const { JSDOM } = require('jsdom');
+
+const ContentManager = require('../js/content-manager.js');
+
+describe('ContentManager', () => {
+  let window, document, cm;
+
+  beforeEach(() => {
+    const dom = new JSDOM('<input id="s"><select id="c"><option value="all">All</option></select><div class="list"></div>', { url: 'https://example.com' });
+    window = dom.window;
+    document = window.document;
+    global.window = window;
+    global.document = document;
+    cm = new ContentManager({ articleUrl: 'test.json', storage: window.localStorage });
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([
+      { id: 1, title: 'AI News', category: 'NLP' },
+      { id: 2, title: 'Vision Paper', category: 'Vision' }
+    ]) }));
+    cm.attach({ searchInput: '#s', categorySelect: '#c', list: '.list' });
+  });
+
+  test('load renders articles', async () => {
+    await cm.load();
+    expect(document.querySelectorAll('.post').length).toBe(2);
+  });
+
+  test('filter by search term', () => {
+    cm.articles = [{ id: 1, title: 'hello', category: 'NLP' }];
+    const res = cm.filter('hell', 'all');
+    expect(res.length).toBe(1);
+  });
+
+  test('bookmark toggles state', () => {
+    cm.toggleBookmark(5);
+    expect(cm.isBookmarked(5)).toBe(true);
+    cm.toggleBookmark(5);
+    expect(cm.isBookmarked(5)).toBe(false);
+  });
+
+  test('filter by category', () => {
+    cm.articles = [
+      { id: 1, title: 'a', category: 'NLP' },
+      { id: 2, title: 'b', category: 'Vision' }
+    ];
+    const res = cm.filter('', 'NLP');
+    expect(res.length).toBe(1);
+    expect(res[0].category).toBe('NLP');
+  });
+
+  test('trackReading saves progress', () => {
+    cm.saveProgress = jest.fn();
+    cm.trackReading('123');
+    window.dispatchEvent(new window.Event('scroll'));
+    expect(cm.saveProgress).toHaveBeenCalled();
+  });
+
+  test('loading and error states modify DOM', () => {
+    const list = document.querySelector('.list');
+    cm.setLoading(true);
+    expect(list.classList.contains('content--loading')).toBe(true);
+    cm.setLoading(false);
+    cm.setError('err');
+    expect(list.textContent).toBe('err');
+    expect(list.classList.contains('content--error')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `ContentManager` class for stateful content handling
- support bookmark toggling, progress tracking and filtering
- integrate module on all pages
- add basic styles for loading state and bookmark button
- create unit tests ensuring new module works
- collect coverage for new file

## Testing
- `npm test`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6863268c46c0832298716a0fbc4ace52