### PR TITLE
Add service worker and manifest for PWA

### DIFF
--- a/assets/images/icons/icon-192.txt
+++ b/assets/images/icons/icon-192.txt
@@ -1,0 +1,1 @@
+icon placeholder

--- a/assets/images/icons/icon-512.txt
+++ b/assets/images/icons/icon-512.txt
@@ -1,0 +1,1 @@
+icon placeholder

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -105,6 +105,13 @@
     });
   }
 
+  function registerServiceWorker(win) {
+    if (!('serviceWorker' in win.navigator)) return;
+    win.addEventListener('load', function(){
+      win.navigator.serviceWorker.register('/sw.js').catch(function(){});
+    });
+  }
+
   /**
    * Initialize all site scripts.
    * @param {Window} [win=window] - Window context.
@@ -122,6 +129,7 @@
     initFadeIn(doc, win);
     initSmoothScroll(doc);
     initLoader(win, doc);
+    registerServiceWorker(win);
     if (win.filterUtils) {
       var utils = win.filterUtils;
       utils.setupSearch('#news-search', '.news-list');

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="preload" as="style" href="css/performance-optimized.css">
     <link rel="stylesheet" href="css/performance-optimized.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="manifest" href="manifest.json">
     <script defer src="assets/js/filter.cjs"></script>
     <script defer src="js/autocomplete.cjs"></script>
     <script defer src="assets/js/main.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "AI Tech News",
+  "short_name": "AI News",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0EA5E9",
+  "icons": [
+    {
+      "src": "assets/images/icons/icon-192.txt",
+      "sizes": "192x192",
+      "type": "text/plain"
+    },
+    {
+      "src": "assets/images/icons/icon-512.txt",
+      "sizes": "512x512",
+      "type": "text/plain"
+    }
+  ]
+}

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Offline</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="site site--light">
+    <h1>You are offline</h1>
+    <p>The requested page is unavailable. Please check your connection.</p>
+</body>
+</html>

--- a/pages/about.html
+++ b/pages/about.html
@@ -6,6 +6,7 @@
     <meta name="description" content="About Generative AI Hub">
     <title>About - Generative AI Hub</title>
     <link rel="stylesheet" href="../css/style.css">
+    <link rel="manifest" href="../manifest.json">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
 </head>

--- a/pages/article.html
+++ b/pages/article.html
@@ -12,6 +12,7 @@
     <meta property="og:image" content="../assets/images/article-800.txt">
     <title>News Article - Generative AI Hub</title>
     <link rel="stylesheet" href="../css/style.css">
+    <link rel="manifest" href="../manifest.json">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
     <script type="module" src="../js/content-manager.js"></script>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -6,6 +6,7 @@
     <meta name="description" content="Contact Generative AI Hub">
     <title>Contact - Generative AI Hub</title>
     <link rel="stylesheet" href="../css/style.css">
+    <link rel="manifest" href="../manifest.json">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
 </head>

--- a/pages/news.html
+++ b/pages/news.html
@@ -6,6 +6,7 @@
     <meta name="description" content="Latest AI News">
     <title>AI News - Generative AI Hub</title>
     <link rel="stylesheet" href="../css/style.css">
+    <link rel="manifest" href="../manifest.json">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
     <script type="module" src="../js/content-manager.js"></script>

--- a/pages/paper.html
+++ b/pages/paper.html
@@ -11,6 +11,7 @@
     <meta property="og:image" content="../assets/images/paper-800.txt">
     <title>Research Paper - Generative AI Hub</title>
     <link rel="stylesheet" href="../css/style.css">
+    <link rel="manifest" href="../manifest.json">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
     <script type="module" src="../js/content-manager.js"></script>

--- a/pages/research.html
+++ b/pages/research.html
@@ -6,6 +6,7 @@
     <meta name="description" content="Generative AI Research Papers">
     <title>Research - Generative AI Hub</title>
     <link rel="stylesheet" href="../css/style.css">
+    <link rel="manifest" href="../manifest.json">
     <script defer src="../assets/js/filter.cjs"></script>
     <script defer src="../assets/js/main.js"></script>
     <script type="module" src="../js/content-manager.js"></script>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,74 @@
+const PRECACHE = 'precache-v1';
+const RUNTIME = 'runtime';
+const PRECACHE_URLS = [
+  '/',
+  'index.html',
+  'offline.html',
+  'css/style.css',
+  'css/performance-optimized.css',
+  'css/design-system/base.css',
+  'css/design-system/utilities.css',
+  'css/design-system/tokens.css',
+  'css/design-system/components/buttons.css',
+  'css/design-system/components/cards.css',
+  'css/design-system/components/forms.css',
+  'css/design-system/components/modal.css'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(PRECACHE).then(cache => cache.addAll(PRECACHE_URLS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  const current = [PRECACHE, RUNTIME];
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => !current.includes(k)).map(k => caches.delete(k)))
+    )
+  );
+});
+
+function cacheFirst(req, cacheName) {
+  return caches.open(cacheName).then(c =>
+    c.match(req).then(r => r || fetch(req).then(res => {
+      if (res.status === 200) c.put(req, res.clone());
+      return res;
+    }))
+  );
+}
+
+function staleWhileRevalidate(req, cacheName) {
+  return caches.open(cacheName).then(c =>
+    c.match(req).then(r => {
+      const fetchP = fetch(req).then(res => {
+        if (res.status === 200) c.put(req, res.clone());
+        return res;
+      }).catch(() => r);
+      return r || fetchP;
+    })
+  );
+}
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+  if (request.destination === 'script' && (url.pathname.startsWith('/assets/js/') || url.pathname.startsWith('/js/'))) {
+    event.respondWith(cacheFirst(request, RUNTIME));
+    return;
+  }
+  if (request.destination === 'style' && url.pathname.startsWith('/css/design-system/')) {
+    event.respondWith(cacheFirst(request, PRECACHE));
+    return;
+  }
+  if (url.pathname.startsWith('/assets/fonts/') || url.pathname.startsWith('/assets/images/')) {
+    event.respondWith(staleWhileRevalidate(request, RUNTIME));
+    return;
+  }
+  if (request.headers.get('accept') && request.headers.get('accept').includes('text/html')) {
+    event.respondWith(
+      fetch(request).catch(() => caches.match('offline.html'))
+    );
+  }
+});

--- a/test/pwa.test.cjs
+++ b/test/pwa.test.cjs
@@ -1,0 +1,33 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const mainUtils = require('../assets/js/main.js');
+
+const pages = [
+  'index.html',
+  'pages/about.html',
+  'pages/article.html',
+  'pages/contact.html',
+  'pages/news.html',
+  'pages/paper.html',
+  'pages/research.html'
+];
+
+test('all pages include manifest link', () => {
+  pages.forEach(p => {
+    const html = fs.readFileSync(p, 'utf8');
+    const dom = new JSDOM(html);
+    const link = dom.window.document.querySelector('link[rel="manifest"]');
+    expect(link).not.toBeNull();
+  });
+});
+
+test('service worker registers when supported', () => {
+  const html = fs.readFileSync('index.html', 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'https://example.com' });
+  const win = dom.window;
+  win.navigator.serviceWorker = { register: jest.fn(() => Promise.resolve()) };
+  win.matchMedia = () => ({ matches: false, addEventListener: () => {} });
+  win.addEventListener = (ev, cb) => { if (ev === 'load') cb(); };
+  mainUtils.init(win, win.document, win.localStorage);
+  expect(win.navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js');
+});


### PR DESCRIPTION
## Summary
- implement `sw.js` with caching strategies and offline fallback
- create `manifest.json` with app details and icon placeholders
- add offline page and register service worker in `main.js`
- include manifest link across HTML pages
- test manifest link and service worker registration
- replace binary icons with text placeholders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864975aeee083229d31d65634b9da7e