### PR TITLE
Improve service worker registration

### DIFF
--- a/test/pwa.test.cjs
+++ b/test/pwa.test.cjs
@@ -21,13 +21,13 @@ test('all pages include manifest link', () => {
   });
 });
 
-test('service worker registers when supported', () => {
+test('service worker registers when supported', async () => {
   const html = fs.readFileSync('index.html', 'utf8');
   const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'https://example.com' });
   const win = dom.window;
   win.navigator.serviceWorker = { register: jest.fn(() => Promise.resolve()) };
   win.matchMedia = () => ({ matches: false, addEventListener: () => {} });
-  win.addEventListener = (ev, cb) => { if (ev === 'load') cb(); };
   mainUtils.init(win, win.document, win.localStorage);
+  await Promise.resolve();
   expect(win.navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js');
 });


### PR DESCRIPTION
## Summary
- register the service worker asynchronously using AbortController
- handle registration errors with a custom ServiceWorkerError
- update PWA test for new registration timing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864a778bcac832285335a86e6502bad